### PR TITLE
fix: Add large pages sizes to prevent partial imports

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -2,7 +2,7 @@ TERRAFORM_INITAL_CONTENT='''terraform {
   required_providers {
     azion = {
       source = "aziontech/azion"
-      version = "~> 1.12.0"
+      version = "~> 1.16.0"
     }
   }
 }
@@ -10,11 +10,14 @@ TERRAFORM_INITAL_CONTENT='''terraform {
 '''
 
 TERRAFORM_IDNS_DATA='''
-data "azion_intelligent_dns_zones" "all_zones" {}
+data "azion_intelligent_dns_zones" "all_zones" {
+  page_size = 1000000
+}
 
 data "azion_intelligent_dns_records" "records" {
   for_each = { for zone in data.azion_intelligent_dns_zones.all_zones.results : zone.zone_id => zone }
-    zone_id = each.value.zone_id
+  zone_id = each.value.zone_id
+  page_size = 1000000
 }
 
 '''


### PR DESCRIPTION
When importing resources from datasources with more than 10 items, only the first 10 was being imported. This PR fixes that by adding larger pages when querying these data sources.